### PR TITLE
fix: remove invalid option for front-matter_linter.js

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           yarn markdownlint-cli2-fix "**/${{ matrix.lang }}/**/*.md"
           yarn prettier -w "**/${{ matrix.lang }}/**/*.md"
-          cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json --files "${{ github.workspace }}/files/${{ matrix.lang }}"
+          cd ${{ github.workspace }}/mdn/content && yarn fix:fm --config-file ${{ github.workspace }}/front-matter-config.json "${{ github.workspace }}/files/${{ matrix.lang }}"
 
       - name: Create PR with only fixable issues
         if: success()


### PR DESCRIPTION
I found there's invalid option(`--files`) usage on front-matter lint script, which causes the workflow to fail.
You can see https://github.com/mdn/translated-content/actions/workflows/markdown-lint-fix.yml to find more information about it.

![image](https://github.com/SnowMarble/translated-content/assets/69508345/81065181-f533-4d17-9d76-51f4e81c3005)

so, I remove the option.